### PR TITLE
Add naming convention for storage accounts

### DIFF
--- a/entity.json
+++ b/entity.json
@@ -2846,8 +2846,8 @@
             "scope": "global",
             "maxlength": "24",
             "rule": "a9",
-            "convention": "",
-            "example": ""
+            "convention": "<rba.productGroup><rba.subscriptionType>",
+            "example": "accurintproduction"
         }
     ],
     "storageAccounts/blobServices": [

--- a/entity.yaml
+++ b/entity.yaml
@@ -2087,8 +2087,8 @@ storageAccounts:
     scope: global
     maxlength: '24'
     rule: a9
-    convention: ''
-    example: ''
+    convention: <rba.productGroup><rba.subscriptionType>
+    example: accurintproduction
 storageAccounts/blobServices:
 -   category: Storage
     entity: blobServices


### PR DESCRIPTION
I suggest aligning the names of storage accounts with key vaults, as they are very similar under Azure requirements: globally unique, 3-24 characters. The main difference is that key vaults can have hyphens, storage accounts cannot. Since our convention for key vaults does not include hyphens anyway, I think it makes sense to make storage accounts the same. 