### PR TITLE
Remove "postgres" word from postgres database name convention

### DIFF
--- a/entity.json
+++ b/entity.json
@@ -33,8 +33,8 @@
             "scope": "global",
             "maxlength": "63",
             "rule": "a-9",
-            "convention": "<rba.productName>-<rba.environment>-postgres##",
-            "example": "tfe-prod-postgres01"
+            "convention": "<rba.productName>-<rba.environment>##",
+            "example": "tfe-prod01"
         },
         {
             "category": "Sql",

--- a/entity.yaml
+++ b/entity.yaml
@@ -25,8 +25,8 @@ servers:
     scope: global
     maxlength: '63'
     rule: a-9
-    convention: <rba.productName>-<rba.environment>-postgres##
-    example: tfe-prod-postgres01
+    convention: <rba.productName>-<rba.environment>##
+    example: tfe-prod01
 -   category: Sql
     entity: servers
     scope: global


### PR DESCRIPTION
When you create an Azure Database endpoint, it creates a DNS name that already includes the type of database used. In the case of Postgres, you get a hostname that looks like this:

\<your-server-name>.postgres.database.azure.com

If we kept the word "postgres" in our naming convention, our servers' hostnames would look like this:

tfe-prod-postgres01.postgres.database.azure.com

Therefore I suggest we omit that from the naming convention in order to avoid this repetition.